### PR TITLE
Add support for inline comments in .env files

### DIFF
--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -28,6 +28,8 @@ KeyOff=off
 KeyEmpty=
 
 #CommentedKey=None
+InlineComments=Foo  # This is an inline comment
+HashContent=Foo 'Bar # Baz' %(key)s  # This is an inline comment
 PercentNotEscaped=%%
 NoInterpolation=%(KeyOff)s
 '''
@@ -75,3 +77,9 @@ def test_env_default_none(config):
 
 def test_env_empty(config):
     assert '' is config('KeyEmpty', default=None)
+
+def test_env_inline_comment(config):
+    assert 'Foo' == config("InlineComments")
+
+def test_env_inline_comment_with_hash_in_value(config):
+    assert "Foo 'Bar # Baz' %(key)s" == config("HashContent")

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -26,8 +26,10 @@ KeyZero=0
 KeyNo=no
 KeyOff=off
 KeyEmpty=
+KeyEmptyWithComments=  # no comments
 
 #CommentedKey=None
+InvalidKey#Skipped
 InlineComments=Foo  # This is an inline comment
 HashContent=Foo 'Bar # Baz' %(key)s  # This is an inline comment
 PercentNotEscaped=%%
@@ -78,8 +80,15 @@ def test_env_default_none(config):
 def test_env_empty(config):
     assert '' is config('KeyEmpty', default=None)
 
+def test_env_empty_with_comments(config):
+    assert '' is config('KeyEmptyWithComments', default=None)
+
 def test_env_inline_comment(config):
     assert 'Foo' == config("InlineComments")
 
 def test_env_inline_comment_with_hash_in_value(config):
     assert "Foo 'Bar # Baz' %(key)s" == config("HashContent")
+
+def test_env_undefined_for_invalid_key(config):
+    with pytest.raises(UndefinedValueError):
+        config('InvalidKey')


### PR DESCRIPTION
Use `shlex` module to make `.env` file parsing more reliable and allow inline comments.

Next step: allow `export FOO=bar` sentences in `.env` files.