### PR TITLE
Add RepositoryChain to allow repository priority

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -196,21 +196,32 @@ How it works?
 
 - ``RepositoryEnv``
 
-    Can read ``.env`` files and when a parameter does not exist there,
-    it tries to find it on ``os.environ``.
+    Can read ``.env`` files.
 
     This process does **not** change nor add any environment variables.
 
 - ``RepositoryShell``
 
-    Can only read values from ``os.environ``.
+    Can read values from ``os.environ``.
+
+- ``RepositoryChain``
+
+    Receives a list of repositories and iterate over then to retrive parameters.
+
+    Return the first value found.
 
 - ``AutoConfig``
 
     Detects which configuration repository you're using.
 
-    It recursively searches up your configuration module path looking for a
-    ``settings.ini`` or a ``.env`` file.
+    By default, ``AutoConfig`` creates a ``RepositoryChain`` using
+    ``RepositoryShell`` at the hightest priority and it recursively searches up
+    your configuration module path looking for a ``settings.ini`` and/or a
+    ``.env`` file. All configuration files found will be chained.
+
+    This means that environment variables are used if defined, with fallback to
+    the configuration files.
+
 
 The **config** object is an instance of ``AutoConfig`` to improve
 *decouple*'s usage.

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -12,11 +12,29 @@ def test_autoconfig_env():
         assert 'ENV' == config('KEY')
 
 
+def test_autoconfig_env_override():
+    os.environ['KEY'] = 'ENV VAR'
+    config = AutoConfig()
+    path = os.path.join(os.path.dirname(__file__), 'autoconfig', 'env', 'project')
+    with patch.object(config, '_caller_path', return_value=path):
+        assert 'ENV VAR' == config('KEY')
+    del os.environ['KEY']
+
+
 def test_autoconfig_ini():
     config = AutoConfig()
     path = os.path.join(os.path.dirname(__file__), 'autoconfig', 'ini', 'project')
     with patch.object(config, '_caller_path', return_value=path):
         assert 'INI' == config('KEY')
+
+
+def test_autoconfig_ini_override():
+    os.environ['KEY'] = 'INI VAR'
+    config = AutoConfig()
+    path = os.path.join(os.path.dirname(__file__), 'autoconfig', 'ini', 'project')
+    with patch.object(config, '_caller_path', return_value=path):
+        assert 'INI VAR' == config('KEY')
+    del os.environ['KEY']
 
 
 def test_autoconfig_none():

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -66,7 +66,8 @@ def test_env_bool_false(config):
 def test_env_os_environ(config):
     os.environ['KeyFallback'] = 'On'
     assert True == config('KeyTrue', cast=bool)
-    assert True == config('KeyFallback', cast=bool)
+    with pytest.raises(UndefinedValueError):
+        config('KeyFallback', cast=bool)
     del os.environ['KeyFallback']
 
 def test_env_undefined(config):


### PR DESCRIPTION
Add `RepositoryChain` to allow repository priority and inspection of more than once repository with priority fallback.

Attempt to fix #9.

- Removes `RepositoryEnv` fallback to `os.environ`;
- Add `RepositoryChain` that accept a list of repositories and iterate over then on getting variables;
- Uses `RepositoryShell` to inspect environment variables before all the others repositories (first on chain);
- Repositories discovery now includes all repositories found into path (with fallback chain using closer to the parent path as priority);
- README updated.

This means that environment variables are used if defined, with fallback to the configuration files.

Best regards!