### PR TITLE
Check if filepath is really a file, not a directory.

### DIFF
--- a/decouple.py
+++ b/decouple.py
@@ -161,7 +161,7 @@ class AutoConfig(object):
         # look for all files in the current path
         for configfile in self.SUPPORTED:
             filename = os.path.join(path, configfile)
-            if os.path.exists(filename):
+            if os.path.isfile(filename):
                 return filename
 
         # search the parent

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -23,7 +23,7 @@ def test_autoconfig_none():
     os.environ['KeyFallback'] = 'On'
     config = AutoConfig()
     path = os.path.join(os.path.dirname(__file__), 'autoconfig', 'none')
-    with patch('os.path.exists', return_value=False):
+    with patch('os.path.isfile', return_value=False):
         assert True == config('KeyFallback', cast=bool)
     del os.environ['KeyFallback']
 
@@ -31,6 +31,14 @@ def test_autoconfig_none():
 def test_autoconfig_exception():
     os.environ['KeyFallback'] = 'On'
     config = AutoConfig()
-    with patch('os.path.exists', side_effect=Exception('PermissionDenied')):
+    with patch('os.path.isfile', side_effect=Exception('PermissionDenied')):
+        assert True == config('KeyFallback', cast=bool)
+    del os.environ['KeyFallback']
+
+
+def test_autoconfig_is_not_a_file():
+    os.environ['KeyFallback'] = 'On'
+    config = AutoConfig()
+    with patch('os.path.isfile', return_value=False):
         assert True == config('KeyFallback', cast=bool)
     del os.environ['KeyFallback']


### PR DESCRIPTION
Due to OpenShift filesystem[1] with a .env directory, decouple must check if .env is a file. Otherwise it will fail because .env is a directory in OpenShift Containers.

[1] https://developers.openshift.com/en/managing-filesystem.html#env