### PR TITLE
Fixes bug while looking for config file in parent dirs

### DIFF
--- a/decouple.py
+++ b/decouple.py
@@ -174,7 +174,7 @@ class AutoConfig(object):
     def _load(self, path):
         # Avoid unintended permission errors
         try:
-            filename = self._find_file(path)
+            filename = self._find_file(os.path.abspath(path))
         except Exception:
             filename = ''
         Repository = self.SUPPORTED.get(os.path.basename(filename))

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -18,6 +18,24 @@ def test_autoconfig_ini():
     with patch.object(config, '_caller_path', return_value=path):
         assert 'INI' == config('KEY')
 
+def test_autoconfig_ini_in_subdir():
+    """
+    When `AutoConfig._find_file()` gets a relative path from
+    `AutoConfig._caller_path()`, it will not properly search back to parent
+    dirs.
+
+    This is a regression test to make sure that when
+    `AutoConfig._caller_path()` finds something like `./config.py` it will look
+    for settings.ini in parent directories.
+    """
+    config = AutoConfig()
+    subdir = os.path.join(os.path.dirname(__file__), 'autoconfig', 'ini',
+            'project', 'subdir')
+    os.chdir(subdir)
+    path = os.path.join(os.path.curdir, 'empty.py')
+    with patch.object(config, '_caller_path', return_value=path):
+        assert 'INI' == config('KEY')
+
 
 def test_autoconfig_none():
     os.environ['KeyFallback'] = 'On'


### PR DESCRIPTION
When `AutoConfig._find_file()` gets a relative path from `AutoConfig._caller_path()`, it will not properly search back to parent dirs. This makes sure `_find_file()` gets an absolute path from `_load()`. 

I found this bug because my `settings.ini` was in the user's home directory and the config module that imported python-decouple was being executed from somewhere else. In this case, what happened was that `_caller_path()` returned `./settings.py`. It tried to look for my ini file in `.` and after (obviously) not finding it, gave up.