### PR TITLE
Allow to override initial search path in AutoConfig class.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -223,7 +223,8 @@ How it works?
     Detects which configuration repository you're using.
 
     It recursively searches up your configuration module path looking for a
-    ``settings.ini`` or a ``.env`` file.
+    ``settings.ini`` or a ``.env`` file. Optionally, it accepts an initial
+    search path argument.
 
 The **config** object is an instance of ``AutoConfig`` to improve
 *decouple*'s usage.

--- a/decouple.py
+++ b/decouple.py
@@ -147,13 +147,21 @@ class RepositoryShell(RepositoryBase):
 class AutoConfig(object):
     """
     Autodetects the config file and type.
+
+    Parameters
+    ----------
+    search_path : str, optional
+        Initial search path. If empty, the default search path is the
+        caller's path.
+
     """
     SUPPORTED = {
         'settings.ini': RepositoryIni,
         '.env': RepositoryEnv,
     }
 
-    def __init__(self):
+    def __init__(self, search_path=None):
+        self.search_path = search_path
         self.config = None
 
     def _find_file(self, path):
@@ -192,7 +200,7 @@ class AutoConfig(object):
 
     def __call__(self, *args, **kwargs):
         if not self.config:
-            self._load(self._caller_path())
+            self._load(self.search_path or self._caller_path())
 
         return self.config(*args, **kwargs)
 

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -12,6 +12,12 @@ def test_autoconfig_env():
         assert 'ENV' == config('KEY')
 
 
+def test_autoconfig_search_path():
+    path = os.path.join(os.path.dirname(__file__), 'autoconfig', 'env', 'project')
+    config = AutoConfig(path)
+    assert 'ENV' == config('KEY')
+
+
 def test_autoconfig_ini():
     config = AutoConfig()
     path = os.path.join(os.path.dirname(__file__), 'autoconfig', 'ini', 'project')


### PR DESCRIPTION
This allows the users to override the initial search path, for example,
when using `decouple` out of a configuration file (i.e.: a jupyter
notebook).
