### PR TITLE
Use context manager when opening files

### DIFF
--- a/decouple.py
+++ b/decouple.py
@@ -96,7 +96,8 @@ class RepositoryIni(RepositoryBase):
 
     def __init__(self, source):
         self.parser = ConfigParser()
-        self.parser.readfp(open(source))
+        with open(source) as file_:
+            self.parser.readfp(file_)
 
     def __contains__(self, key):
         return (key in os.environ or
@@ -114,14 +115,15 @@ class RepositoryEnv(RepositoryBase):
     def __init__(self, source):
         self.data = {}
 
-        for line in open(source):
-            line = line.strip()
-            if not line or line.startswith('#') or '=' not in line:
-                continue
-            k, v = line.split('=', 1)
-            k = k.strip()
-            v = v.strip().strip('\'"')
-            self.data[k] = v
+        with open(source) as file_:
+            for line in file_:
+                line = line.strip()
+                if not line or line.startswith('#') or '=' not in line:
+                    continue
+                k, v = line.split('=', 1)
+                k = k.strip()
+                v = v.strip().strip('\'"')
+                self.data[k] = v
 
     def __contains__(self, key):
         return key in os.environ or key in self.data

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -12,7 +12,7 @@ PY3 = sys.version_info[0] == 3
 if PY3:
     from io import StringIO
 else:
-    from StringIO import StringIO
+    from io import BytesIO as StringIO
 
 
 ENVFILE = '''

--- a/tests/test_ini.py
+++ b/tests/test_ini.py
@@ -11,7 +11,7 @@ PY3 = sys.version_info[0] == 3
 if PY3:
     from io import StringIO
 else:
-    from StringIO import StringIO
+    from io import BytesIO as StringIO
 
 
 


### PR DESCRIPTION
Currently, files are not closed after reading in configuration. By
adding a context manager, files are closed automatically.

Additionally, update Python 2 tests to use the more modern ``io.BytesIO``
instead of ``StringIO.StringIO`` to support the usage of context
managers.