### PR TITLE
Support to YAML files as config

### DIFF
--- a/decouple.py
+++ b/decouple.py
@@ -3,6 +3,7 @@ import os
 import sys
 import string
 from shlex import shlex
+from yaml import load
 
 
 # Useful for very coarse version differentiation.
@@ -139,6 +140,25 @@ class RepositoryEnv(RepositoryEmpty):
         return self.data[key]
 
 
+class RepositoryYaml(RepositoryEmpty):
+    """
+    Retrieves option keys from .ini files.
+    """
+    SECTION = 'settings'
+
+    def __init__(self, source):
+        self.parse = load
+        with open(source) as file_:
+            self.data = self.parse(file_)
+
+    def __contains__(self, key):
+        return (key in os.environ or
+                key in self.data[self.SECTION])
+
+    def __getitem__(self, key):
+        return self.data[self.SECTION].get(key)
+
+
 class AutoConfig(object):
     """
     Autodetects the config file and type.
@@ -153,6 +173,7 @@ class AutoConfig(object):
     SUPPORTED = {
         'settings.ini': RepositoryIni,
         '.env': RepositoryEnv,
+        'settings.yaml': RepositoryYaml
     }
 
     def __init__(self, search_path=None):

--- a/decouple.py
+++ b/decouple.py
@@ -3,7 +3,7 @@ import os
 import sys
 import string
 from shlex import shlex
-from yaml import load
+from yaml import load as yaml_load
 
 
 # Useful for very coarse version differentiation.
@@ -142,12 +142,12 @@ class RepositoryEnv(RepositoryEmpty):
 
 class RepositoryYaml(RepositoryEmpty):
     """
-    Retrieves option keys from .ini files.
+    Retrieves option keys from .yaml files.
     """
     SECTION = 'settings'
 
     def __init__(self, source):
-        self.parse = load
+        self.parse = yaml_load
         with open(source) as file_:
             self.data = self.parse(file_)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest==3.2.0
 tox==2.7.0
 docutils==0.14
 Pygments==2.2.0
+PyYAML==3.12

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,0 +1,123 @@
+# coding: utf-8
+import os
+import sys
+from mock import patch
+import pytest
+from decouple import Config, RepositoryYaml, UndefinedValueError
+
+
+# Useful for very coarse version differentiation.
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    from io import StringIO
+else:
+    from io import BytesIO as StringIO
+
+
+YAMLFILE = '''
+settings:
+    KeyTrue: true
+    KeyOne: 1
+    KeyYes: yes
+    KeyOn: on
+
+    KeyFalse: false
+    KeyZero: 0
+    KeyNo: no
+    KeyOff: off
+    KeyEmpty: ''
+
+    #CommentedKey: None
+    IgnoreSpace:  text
+    RespectSingleQuoteSpace :  ' text'
+    RespectDoubleQuoteSpace :  " text"
+    KeyOverrideByEnv: NotThis
+
+    List:
+        - Item1
+        - Item2
+        - Item3
+
+    Repeat: &id1
+        Node1: 1
+        Node2: 2
+
+    RepeatedNode: *id1
+    ChangeNode:
+        <<: *id1
+        Node2: 3
+'''
+
+
+@pytest.fixture(scope='module')
+def config():
+    with patch('decouple.open', return_value=StringIO(YAMLFILE), create=True):
+        return Config(RepositoryYaml('settings.yaml'))
+
+
+def test_yaml_comment(config):
+    with pytest.raises(UndefinedValueError):
+        config('CommentedKey')
+
+
+def test_yaml_bool_true(config):
+    assert True is config('KeyTrue', cast=bool)
+    assert True is config('KeyOne', cast=bool)
+    assert True is config('KeyYes', cast=bool)
+    assert True is config('KeyOn', cast=bool)
+
+
+def test_yaml_bool_false(config):
+    assert False is config('KeyFalse', cast=bool)
+    assert False is config('KeyZero', cast=bool)
+    assert False is config('KeyNo', cast=bool)
+    assert False is config('KeyOff', cast=bool)
+
+
+def test_yaml_os_environ(config):
+    os.environ['KeyOverrideByEnv'] = 'This'
+    assert 'This' == config('KeyOverrideByEnv')
+    del os.environ['KeyOverrideByEnv']
+
+
+def test_yaml_undefined_but_present_in_os_environ(config):
+    os.environ['KeyOnlyEnviron'] = ''
+    assert '' == config('KeyOnlyEnviron')
+    del os.environ['KeyOnlyEnviron']
+
+
+def test_yaml_undefined(config):
+    with pytest.raises(UndefinedValueError):
+        config('UndefinedKey')
+
+
+def test_yaml_default_none(config):
+    assert None is config('UndefinedKey', default=None)
+
+
+def test_yaml_empty(config):
+    assert '' == config('KeyEmpty', default=None)
+    assert '' == config('KeyEmpty')
+
+
+def test_yaml_support_space(config):
+    assert 'text' == config('IgnoreSpace')
+    assert ' text' == config('RespectSingleQuoteSpace')
+    assert ' text' == config('RespectDoubleQuoteSpace')
+
+
+def test_yaml_empty_string_means_false(config):
+    assert False is config('KeyEmpty', cast=bool)
+
+
+def test_yaml_list(config):
+    assert isinstance(config('List'), list)
+    assert len(config('List')) == 3
+
+
+def test_yaml_repeated_node(config):
+    assert config('RepeatedNode')['Node1'] == 1
+    assert config('RepeatedNode')['Node2'] == 2
+
+    assert config('ChangeNode')['Node2'] == 3

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,5 @@ envlist = py27, py36
 deps =
     mock==2.0.0
     pytest==3.2.0
+    PyYAML==3.12
 commands=py.test


### PR DESCRIPTION
I really like YAML, and I like YAML as config file. It has a beautiful syntax and has so many interesting features that makes YAML able to be used as config files, supporting those features and still readable.

And, I really like decouple, so I decided to make this PR in order to be able to use this together.

Thx.