### PR TITLE
Include LICENSE file in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license-file = LICENSE


### PR DESCRIPTION
Redistributions of your source code are supposed to include the LICENSE text under your BSD, but your distributions currently don't. The MANIFEST.in file makes sure that this file ends up in the .tar.gz source files from sdist, and the setup.cfg file tells wheels about it.

ref: https://github.com/conda-forge/staged-recipes/pull/3966