### PR TITLE
fix(_find_file): avoid stack overflow on windows

### DIFF
--- a/decouple.py
+++ b/decouple.py
@@ -168,7 +168,7 @@ class AutoConfig(object):
 
         # search the parent
         parent = os.path.dirname(path)
-        if parent and parent != os.path.sep:
+        if parent and parent != os.path.abspath(os.sep):
             return self._find_file(parent)
 
         # reached root without finding any files.


### PR DESCRIPTION
stop trying to find files when root path of drive has been reached

fixes #52