### PR TITLE
add .items() methods to support dict dump

### DIFF
--- a/decouple.py
+++ b/decouple.py
@@ -110,6 +110,7 @@ class RepositoryIni(RepositoryEmpty):
 
     def __init__(self, source):
         self.parser = ConfigParser()
+        self.parser.optionxform = str
         with open(source) as file_:
             self.parser.readfp(file_)
 

--- a/decouple.py
+++ b/decouple.py
@@ -121,7 +121,7 @@ class RepositoryIni(RepositoryEmpty):
         return self.parser.get(self.SECTION, key)
 
     def items(self):
-        return tuple(self.parser.items(self.SECTION))
+        return self.parser.items(self.SECTION)
 
 
 class RepositoryEnv(RepositoryEmpty):
@@ -148,7 +148,7 @@ class RepositoryEnv(RepositoryEmpty):
         return self.data[key]
 
     def items(self):
-        return tuple((k, v) for k, v in self.data.items())
+        return self.data.items()
 
 
 class AutoConfig(object):

--- a/decouple.py
+++ b/decouple.py
@@ -84,6 +84,9 @@ class Config(object):
         """
         return self.get(*args, **kwargs)
 
+    def items(self):
+        return self.repository.items()
+
 
 class RepositoryEmpty(object):
     def __init__(self, source=''):
@@ -94,6 +97,9 @@ class RepositoryEmpty(object):
 
     def __getitem__(self, key):
         return None
+
+    def items(self):
+        return ()
 
 
 class RepositoryIni(RepositoryEmpty):
@@ -113,6 +119,9 @@ class RepositoryIni(RepositoryEmpty):
 
     def __getitem__(self, key):
         return self.parser.get(self.SECTION, key)
+
+    def items(self):
+        return tuple(self.parser.items(self.SECTION))
 
 
 class RepositoryEnv(RepositoryEmpty):
@@ -137,6 +146,9 @@ class RepositoryEnv(RepositoryEmpty):
 
     def __getitem__(self, key):
         return self.data[key]
+
+    def items(self):
+        return tuple((k, v) for k, v in self.data.items())
 
 
 class AutoConfig(object):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -103,3 +103,7 @@ def test_env_support_space(config):
 
 def test_env_empty_string_means_false(config):
     assert False is config('KeyEmpty', cast=bool)
+
+def test_items_to_dict(config):
+    assert dict(config.items())['IgnoreSpace'] == 'text'
+    assert dict(config.items())['KeyEmpty'] is ''

--- a/tests/test_ini.py
+++ b/tests/test_ini.py
@@ -114,3 +114,8 @@ def test_ini_undefined_but_present_in_os_environ(config):
 
 def test_ini_empty_string_means_false(config):
     assert False is config('KeyEmpty', cast=bool)
+
+def test_items_to_dict(config):
+    assert type(config.items()) is list
+    assert dict(config.items())['IgnoreSpace'] == 'text'
+    assert dict(config.items())['KeyEmpty'] is ''


### PR DESCRIPTION
Added methods to support `dict(config.items())` (#55)

Didn't quite get how to make tests for this case since there is no tests/test_config.py, only tests/test_autoconfig.py.