### PR TITLE
Added Consul repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
+sudo: false
 language: python
-env:
-- TOXENV=py27
-- TOXENV=py36
-install:
- - pip install tox==1.7.0
+python:
+  - "2.7"
+  - "3.6"
+install: pip install tox-travis
 script: tox

--- a/decouple.py
+++ b/decouple.py
@@ -115,6 +115,34 @@ class RepositoryIni(RepositoryEmpty):
         return self.parser.get(self.SECTION, key)
 
 
+class RepositoryConsul(RepositoryEmpty):
+    """
+    Retrieves options keys from a consul connection.
+    """
+    def __init__(self, consul, root=''):
+        """
+        consul: consul.Consul object
+        root: Where to look for keys (prepended to the actual key name)
+        """
+        self.consul = consul
+        self.root = root
+        self.data = {}
+
+    def __contains__(self, key):
+        idx, data = self.consul.kv.get('/'.join([self.root, key]))
+        if not data:
+            return False
+        else:
+            self.data[key] = data.get('Value', None)
+            return True
+
+    def __getitem__(self, key):
+        # Makes sure that the data is loaded
+        if key in self:
+            return self.data[key]
+        return None
+
+
 class RepositoryEnv(RepositoryEmpty):
     """
     Retrieves option keys from .env files with fall back to os.environ.

--- a/decouple.py
+++ b/decouple.py
@@ -120,12 +120,15 @@ class RepositoryConsul(RepositoryEmpty):
     """
     Retrieves options keys from a consul connection.
     """
-    def __init__(self, consul, root=''):
+    def __init__(self, consul, root='', encoding=None):
         """
         consul: consul.Consul object
         root: Where to look for keys (prepended to the actual key name)
+        encoding: Which encoding to be used when returning values. The value
+        will not be decoded if encoding is None
         """
         self.consul = consul
+        self.encoding = encoding
         self.root = root
         self.data = {}
 
@@ -140,7 +143,10 @@ class RepositoryConsul(RepositoryEmpty):
     def __getitem__(self, key):
         # Makes sure that the data is loaded
         if key in self:
-            return self.data[key]
+            value = self.data[key]
+            if self.encoding:
+                return value.decode(self.encoding)
+            return value
         return None
 
 

--- a/tests/test_consul.py
+++ b/tests/test_consul.py
@@ -1,0 +1,51 @@
+# coding: utf-8
+import os
+import pytest
+
+from decouple import Config, RepositoryConsul, UndefinedValueError
+
+class FakeConsul(object):
+    """This class is a monkey patch to simulate consul.Consul.kv.get"""
+    def __init__(self, fake_data=None):
+        self.fake_data = fake_data or {}
+        class KV:
+            idx = 0
+            @classmethod
+            def get(cls, key):
+                cls.idx += 1
+                if key in self.fake_data:
+                    return cls.idx, {'Value': self.fake_data[key]}
+                return cls.idx, None
+        self.kv = KV()
+
+
+@pytest.fixture
+def consul():
+    c = FakeConsul()
+    c.fake_data['myapp/secret_key'] = 'some really secure secret key'
+    c.fake_data['myapp/debug'] = False
+    c.fake_data['staging/debug'] = True
+    c.fake_data['unaccessible'] = 'not be accessible if root is set to `myapp`'
+    return c
+
+
+@pytest.fixture
+def config(consul):
+    return Config(RepositoryConsul(consul, 'myapp'))
+
+
+def test_consul_undefined(config):
+    with pytest.raises(UndefinedValueError):
+        # `unaccessible` is defined in a scope that this consul repository
+        # has no access to
+        config('unaccessible')
+
+
+def test_consul_get_bool(config):
+    assert config('debug', cast=bool) is False
+
+
+def test_consul_basic(config):
+    os.environ['unaccessible'] = 'overwrite'
+    assert config('unaccessible') == 'overwrite'
+    del os.environ['unaccessible']


### PR DESCRIPTION
When using `decouple.RepositoryConsul` configuration will be loaded from a [Consul](https://www.consul.io/) server.

Initialization requires an [`consul.Consul`](https://python-consul.readthedocs.io/en/latest/#consul) object to give users flexibility to setup ACL, SSL or any other connection peculiarity from his environment.

`python-consul` is not an requirement.

This MR is replacing #65 as I need to use my master branch for more stuff