### PR TITLE
Added support for skipping environment variables

### DIFF
--- a/decouple.py
+++ b/decouple.py
@@ -38,8 +38,9 @@ class Config(object):
     _BOOLEANS = {'1': True, 'yes': True, 'true': True, 'on': True,
                  '0': False, 'no': False, 'false': False, 'off': False, '': False}
 
-    def __init__(self, repository):
+    def __init__(self, repository, skip_env=False):
         self.repository = repository
+        self.skip_env = skip_env
 
     def _cast_boolean(self, value):
         """
@@ -55,13 +56,13 @@ class Config(object):
     def _cast_do_nothing(value):
         return value
 
-    def get(self, option, default=undefined, cast=undefined):
+    def get(self, option, default=undefined, cast=undefined, skip_env=False):
         """
         Return the value for option or default if defined.
         """
 
         # We can't avoid __contains__ because value may be empty.
-        if option in os.environ:
+        if not self.skip_env and not skip_env and option in os.environ:
             value = os.environ[option]
         elif option in self.repository:
             value = self.repository[option]

--- a/tests/test_ini.py
+++ b/tests/test_ini.py
@@ -106,6 +106,20 @@ def test_ini_os_environ(config):
     del os.environ['KeyOverrideByEnv']
 
 
+def test_skip_env_global(config):
+    config.skip_env = True
+    os.environ['KeyOverrideByEnv'] = 'This'
+    assert 'NotThis' == config('KeyOverrideByEnv')
+    del os.environ['KeyOverrideByEnv']
+    config.skip_env = False
+
+
+def test_skip_env_global(config):
+    os.environ['KeyOverrideByEnv'] = 'This'
+    assert 'NotThis' == config('KeyOverrideByEnv', skip_env=True)
+    del os.environ['KeyOverrideByEnv']
+
+
 def test_ini_undefined_but_present_in_os_environ(config):
     os.environ['KeyOnlyEnviron'] = ''
     assert '' == config('KeyOnlyEnviron')


### PR DESCRIPTION
When calling `config('my_var')` it is now possible to skip environment check.

That is useful when you have a common config var name or just want to skip environment variables altogether.

Per call skipping:
```python
config = Config(RepositoryIni("myconfig.ini"))
ps1 = config("DISPLAY", default=True, cast=bool, skip_env=True)
```

Per config skipping:
```python
config = Config(RepositoryIni("myconfig.ini"), skip_env=True)
home = config("HOME", default="128,13")
```