### PR TITLE
Enforce a search order for settings files

### DIFF
--- a/decouple.py
+++ b/decouple.py
@@ -3,7 +3,7 @@ import os
 import sys
 import string
 from shlex import shlex
-
+from collections import OrderedDict
 
 # Useful for very coarse version differentiation.
 PY3 = sys.version_info[0] == 3
@@ -150,10 +150,10 @@ class AutoConfig(object):
         caller's path.
 
     """
-    SUPPORTED = {
-        'settings.ini': RepositoryIni,
-        '.env': RepositoryEnv,
-    }
+    SUPPORTED = OrderedDict([
+        ('settings.ini', RepositoryIni),
+        ('.env', RepositoryEnv),
+    ])
 
     def __init__(self, search_path=None):
         self.search_path = search_path


### PR DESCRIPTION
Prior to Python 3.7 dictionaries are unordered.  This leads to unpredictable results when you define a settings.ini file and you already have a .env file for other purposes (such as pipenv environment variables).  Sometimes the settings.ini file will be loaded by decouple and sometimes the .env will be loaded.  This change replaces the Python dict with an OrderedDict, which is compatible back to Python 2.7.

This has become the functionality in 3.7, this pull request simply makes it retroactive and removes ambiguity.

Please let me know if you would like to see this done differently, and thanks for creating decouple.