### PR TITLE
Prevent default value of being cast 

### DIFF
--- a/decouple.py
+++ b/decouple.py
@@ -67,10 +67,7 @@ class Config(object):
             if isinstance(default, Undefined):
                 raise UndefinedValueError('{} not found. Declare it as envvar or define a default value.'.format(option))
 
-            value = default
-
-            if cast is not bool:
-                return value
+            return default
 
         if isinstance(cast, Undefined):
             cast = self._cast_do_nothing

--- a/decouple.py
+++ b/decouple.py
@@ -69,6 +69,9 @@ class Config(object):
 
             value = default
 
+            if cast is not bool:
+                return value
+
         if isinstance(cast, Undefined):
             cast = self._cast_do_nothing
         elif cast is bool:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -72,7 +72,7 @@ def test_env_bool_true(config):
     assert True is config('KeyYes', cast=bool)
     assert True is config('KeyOn', cast=bool)
     assert True is config('KeyY', cast=bool)
-    assert True is config('Key1int', default=1, cast=bool)
+    assert True is config('Key1int', default=True, cast=bool)
 
 def test_env_bool_false(config):
     assert False is config('KeyFalse', cast=bool)
@@ -81,7 +81,7 @@ def test_env_bool_false(config):
     assert False is config('KeyOff', cast=bool)
     assert False is config('KeyN', cast=bool)
     assert False is config('KeyEmpty', cast=bool)
-    assert False is config('Key0int', default=0, cast=bool)
+    assert False is config('Key0int', default=False, cast=bool)
 
 
 def test_env_os_environ(config):

--- a/tests/test_ini.py
+++ b/tests/test_ini.py
@@ -94,12 +94,12 @@ def test_ini_default(config):
     assert True is config('UndefinedKey', default=True)
 
 
-def test_ini_default_invalid_bool(config):
+def test_ini_default_type_different_from_cast(config):
     assert 'NotBool' is config('UndefinedKey', default='NotBool', cast=bool)
+    assert None is config('UndefinedKey', default=None, cast=int)
 
 def test_ini_empty(config):
     assert '' is config('KeyEmpty', default=None)
-
 
 def test_ini_support_space(config):
     assert 'text' == config('IgnoreSpace')

--- a/tests/test_ini.py
+++ b/tests/test_ini.py
@@ -62,7 +62,7 @@ def test_ini_bool_true(config):
     assert True is config('KeyYes', cast=bool)
     assert True is config('KeyY', cast=bool)
     assert True is config('KeyOn', cast=bool)
-    assert True is config('Key1int', default=1, cast=bool)
+    assert True is config('Key1int', default=True, cast=bool)
 
 
 def test_ini_bool_false(config):
@@ -72,7 +72,7 @@ def test_ini_bool_false(config):
     assert False is config('KeyOff', cast=bool)
     assert False is config('KeyN', cast=bool)
     assert False is config('KeyEmpty', cast=bool)
-    assert False is config('Key0int', default=0, cast=bool)
+    assert False is config('Key0int', default=False, cast=bool)
 
 
 def test_init_undefined(config):
@@ -95,9 +95,7 @@ def test_ini_default(config):
 
 
 def test_ini_default_invalid_bool(config):
-    with pytest.raises(ValueError):
-        config('UndefinedKey', default='NotBool', cast=bool)
-
+    assert 'NotBool' is config('UndefinedKey', default='NotBool', cast=bool)
 
 def test_ini_empty(config):
     assert '' is config('KeyEmpty', default=None)


### PR DESCRIPTION
The goal behind this PR is to prevent `default` value to be casted.

Got scenario where I cast value I read from environment variable as `int` but in case variable is not present in want it to have default value as `None`. Currently this can't be done since the return value of `get` method is casted (https://github.com/henriquebastos/python-decouple/blob/master/decouple.py#L77). 

As the value passed in `default` is something that is either the same type you define as cast or something of a known type passed (and expected) by user, maybe is not needed to cast it.

Also adjusted tests and tested locally.