### PR TITLE
Test Csv() on Backslash Escaped Strings

### DIFF
--- a/tests/test_helper_csv.py
+++ b/tests/test_helper_csv.py
@@ -29,3 +29,12 @@ def test_csv_quoted_parse():
     assert ['foo', "'bar, baz'", "'qux"] == csv(''' foo ,"'bar, baz'", "'qux"''')
 
     assert ['foo', '"bar, baz"', '"qux'] == csv(""" foo ,'"bar, baz"', '"qux'""")
+
+
+def test_csv_backslash():
+    csv = Csv()
+
+    raw = r'first,^https://\w+\.example\.com$,third'
+
+    assert ['first', '^https://\\w+\\.example\\.com$', 'third'] == \
+        csv(raw), "Csv helper removed backslashes."


### PR DESCRIPTION
Test for #102

A regular expression is often written with backslash escapes.
This change introduces a test to check that the Csv helper does not
strip backslashes from input strings.
