### PR TITLE
Tox GitHub Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,60 @@
+##
+# A GitHub Action to run Tox
+
+name: Tox
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  pull_request:
+    branches:
+    - master
+  push:
+    branches:
+    - master
+    - tox-action
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  py37:
+    runs-on: ubuntu-latest
+    container: python:3.7-alpine
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a single command using the runners shell
+    - name: Install Tox
+      run: pip install --user --upgrade tox
+
+    - name: Run Tox
+      env:
+        TOXENV: py37
+      run: |
+        "$HOME/.local/bin/tox"
+
+  py27:
+    runs-on: ubuntu-latest
+    container: python:2.7-alpine
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a single command using the runners shell
+    - name: Install Tox
+      run: pip install --user --upgrade tox
+
+    - name: Run Tox
+      env:
+        TOXENV: py27
+      run: |
+        "$HOME/.local/bin/tox"
+


### PR DESCRIPTION
Seems that TravisCI stopped working around #93 in February. I thought you might want to use GitHub actions instead. You can see it in [my fork](https://github.com/kojiromike/python-decouple/actions).