### PR TITLE
Avoid DeprecationError on ConfigParser.readfp()

### DIFF
--- a/decouple.py
+++ b/decouple.py
@@ -103,7 +103,8 @@ class RepositoryIni(RepositoryEmpty):
     def __init__(self, source, encoding=DEFAULT_ENCODING):
         self.parser = ConfigParser()
         with open(source, encoding=encoding) as file_:
-            self.parser.readfp(file_)
+            config_reader = self.parser.read_file if sys.version_info >= (3, 2, 0) else self.parser.readfp
+            config_reader(file_)
 
     def __contains__(self, key):
         return (key in os.environ or


### PR DESCRIPTION
Add a Python version check to use `ConfigParser.read_file()` on Python version grater than 3.2.0 (see [docs](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.readfp)).

Improved version of #93.