### PR TITLE
Fix .env -file quote strip.

### DIFF
--- a/decouple.py
+++ b/decouple.py
@@ -136,7 +136,7 @@ class RepositoryEnv(RepositoryEmpty):
                 k = k.strip()
                 v = v.strip()
                 if len(v) >= 2 and ((v[0] == "'" and v[-1] == "'") or (v[0] == '"' and v[-1] == '"')):
-                    v = v.strip('\'"')
+                    v = v[1:-1]
                 self.data[k] = v
 
     def __contains__(self, key):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -45,6 +45,8 @@ KeyWithDoubleQuoteMid=te"xt
 KeyWithDoubleQuoteBegin="text
 KeyIsSingleQuote='
 KeyIsDoubleQuote="
+KeyHasTwoSingleQuote="'Y'"
+KeyHasTwoDoubleQuote='"Y"'
 '''
 
 @pytest.fixture(scope='module')
@@ -128,3 +130,5 @@ def test_env_with_quote(config):
     assert '"text' == config('KeyWithDoubleQuoteBegin')
     assert '"' == config('KeyIsDoubleQuote')
     assert "'" == config('KeyIsSingleQuote')
+    assert "'Y'" == config('KeyHasTwoSingleQuote')
+    assert '"Y"' == config('KeyHasTwoDoubleQuote')


### PR DESCRIPTION
Remove only first and last quotes.

Resolves https://github.com/henriquebastos/python-decouple/issues/123