### PR TITLE
Change strtobool to ignore the to bool conversion

### DIFF
--- a/decouple.py
+++ b/decouple.py
@@ -31,6 +31,8 @@ TRUE_VALUES = {"y", "yes", "t", "true", "on", "1"}
 FALSE_VALUES = {"n", "no", "f", "false", "off", "0"}
 
 def strtobool(value):
+    if isinstance(value, bool):
+        return value
     value = value.lower()
 
     if value in TRUE_VALUES:


### PR DESCRIPTION
Change `strtobool` to ignore the to-bool conversion when the input value is a bool


This pull-request prevents an error from being thrown if the default value is used and it is a `bool` instead of a `string`.


Quick way to reproduce the error:

```python
from decouple import config, strtobool

DEBUG = config('DEBUG', default=False, cast=strtobool)
```


```python
    DEBUG = config('DEBUG', default=False, cast=strtobool)
  File "/home/luzfcb/.virtualenvs/myenv/lib/python3.9/site-packages/decouple.py", line 197, in __call__
    return self.config(*args, **kwargs)
  File "/home/luzfcb/.virtualenvs/myenv/lib/python3.9/site-packages/decouple.py", line 85, in __call__
    return self.get(*args, **kwargs)
  File "/home/luzfcb/.virtualenvs/myenv/lib/python3.9/site-packages/decouple.py", line 79, in get
    return cast(value)
  File "/home/luzfcb/.virtualenvs/myenv/lib/python3.9/site-packages/decouple.py, line 36, in strtobool
    value = value.lower()
AttributeError: 'bool' object has no attribute 'lower'

Process finished with exit code 1

```