### PR TITLE
Fix _find_file parent stop condition

### DIFF
--- a/decouple.py
+++ b/decouple.py
@@ -219,7 +219,7 @@ class AutoConfig(object):
 
         # search the parent
         parent = os.path.dirname(path)
-        if parent and os.path.normcase(parent) != os.path.normcase(os.path.abspath(os.sep)):
+        if parent and os.path.normcase(parent) != os.path.normcase(path):
             return self._find_file(parent)
 
         # reached root without finding any files.


### PR DESCRIPTION
Fixes https://github.com/HBNetwork/python-decouple/issues/172 - infinite recursion if `parent` is on a drive different than the working directory drive under Windows.