### PR TITLE
Fix incorrect use of pathlib.Path method in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -179,7 +179,7 @@ and `dj-database-url <https://pypi.python.org/pypi/dj-database-url/>`_.
     DATABASES = {
         'default': config(
             'DATABASE_URL',
-            default='sqlite:///' + BASE_DIR.child('db.sqlite3'),
+            default='sqlite:///' + BASE_DIR.joinpath('db.sqlite3'),
             cast=db_url
         )
     }


### PR DESCRIPTION
`Path` objects have no `child()` method in the `pathlib` module of the standard library. The method to use is `joinpath()`, or the division operator which also joins paths. So it could also be:

```python
    DATABASES = {
        'default': config(
            'DATABASE_URL',
            default='sqlite:///' + (BASE_DIR / 'db.sqlite3'),
            cast=db_url
        )
    }
```

But that's harder to parse for users unfamiliar with the pathlib module IMO. 